### PR TITLE
Resolve language-style signals for classes/enumeration

### DIFF
--- a/docs/stereotypes/classes/enumeration.md
+++ b/docs/stereotypes/classes/enumeration.md
@@ -4,7 +4,7 @@
 
 Enumeration is an OntoUML stereotype for classes that are treated as particular types of Datatype. In the consulted source, Enumeration is also used in the treatment of quality structures as a datatype-like representational device for a finite space of admissible quality values.
 
-This Phase 1 description is limited to those source-grounded characterizations. The supplied intermediate contribution does not provide a complete stereotype profile for Enumeration.
+This description is limited to those source-grounded characterizations. The supplied intermediate contribution does not provide a complete stereotype profile for Enumeration.
 
 ## Stereotype Profile
 


### PR DESCRIPTION
## Summary

Resolves accepted `language-style-checker` signals from #41.

## Affected page

`docs/stereotypes/classes/enumeration.md`

## Accepted signals

- `S-001` / Group 1: remove project-phase self-reference from the Description section.

## Rejected or deferred signals

- None.

## Changes

- Replaces `This Phase 1 description` with `This description`.

## Review notes

This PR applies only safe local language-style edits. It does not perform conceptual validation, source-faithfulness validation, source checking, citation-support assessment, reference hygiene, Markdown hygiene, encoding hygiene, page-structure checking, or broad rewriting.