### PR TITLE
Resolve language-style signals for classes/situation

### DIFF
--- a/docs/stereotypes/classes/situation.md
+++ b/docs/stereotypes/classes/situation.md
@@ -12,11 +12,11 @@ Situation participates centrally in event triggering, event outcomes, and event 
 
 ## Stereotype Profile
 
-TBD in a later phase.
+Not specified.
 
 ## Examples
 
-TBD in a later phase.
+Not specified.
 
 ## References
 


### PR DESCRIPTION
## Summary

Resolves accepted `language-style-checker` signals from #10.

## Affected page

`docs/stereotypes/classes/situation.md`

## Accepted signals

- Group 2 / S-001: Replace project-phase placeholder in `Stereotype Profile` with neutral wording.
- Group 3 / S-002: Replace project-phase placeholder in `Examples` with neutral wording.

## Rejected or deferred signals

- Group 1 / S-001: Rejected because `understood as a whole at a specific time point` is acceptable professional technical prose and the proposed replacement is a stylistic preference.
- Deferred signals: None.

## Changes

- Replaced `TBD in a later phase.` with `Not specified.` in `Stereotype Profile`.
- Replaced `TBD in a later phase.` with `Not specified.` in `Examples`.

## Review notes

This PR applies only safe local language-style edits. It does not perform conceptual validation, source-faithfulness validation, source checking, citation-support assessment, reference hygiene, Markdown hygiene, encoding hygiene, page-structure checking, or broad rewriting.