### PR TITLE
Resolve language-style signals for relations/historical-dependence

### DIFF
--- a/docs/stereotypes/relations/historical-dependence.md
+++ b/docs/stereotypes/relations/historical-dependence.md
@@ -2,13 +2,13 @@
 
 ## Description
 
-HistoricalDependence is characterized in the supplied Phase 1 sources as an association stereotype for historical dependence between Event instances. It is used for dependencies grounded in causal or precondition-like relations among events and the situations they bring about or trigger.
+HistoricalDependence is characterized in the supplied sources as an association stereotype for historical dependence between Event instances. It is used for dependencies grounded in causal or precondition-like relations among events and the situations they bring about or trigger.
 
 One source specifies four conditions for historical dependence: an event, or one of its parts, may bring about the situation that triggers another event or one of its parts; it may bring about a situation that is necessary but not sufficient for such triggering; it may bring about a situation that is necessary and more than sufficient for such triggering; or the dependence may hold transitively through another historically dependent event. On this account, HistoricalDependence covers direct causation and, through transitivity, indirect causation.
 
 The same source distinguishes HistoricalDependence from mere temporal precedence. HistoricalDependence is presented as the stronger relation: it may represent direct and indirect causation, and it may also represent dependence without causation.
 
-A complementary source places historical relations in a broader relation taxonomy. It distinguishes historical descriptive relations, which hold in virtue of a past quality of a relatum, from merely historical non-descriptive relations, which hold in virtue of a past event. In that account, non-descriptive historical relations need not themselves be reified as relationships, although explicitly modeling the past event may still be useful. For this Phase 1 consolidation, this supports treating historical grounding cautiously: the supplied sources connect HistoricalDependence primarily to event-based dependence, while also recording that some historical relations may be grounded in past qualities.
+A complementary source places historical relations in a broader relation taxonomy. It distinguishes historical descriptive relations, which hold in virtue of a past quality of a relatum, from merely historical non-descriptive relations, which hold in virtue of a past event. In that account, non-descriptive historical relations need not themselves be reified as relationships, although explicitly modeling the past event may still be useful. This supports treating historical grounding cautiously: the supplied sources connect HistoricalDependence primarily to event-based dependence, while also recording that some historical relations may be grounded in past qualities.
 
 ## Stereotype Profile
 


### PR DESCRIPTION
## Summary

Resolves accepted `language-style-checker` signals from #30.

## Affected page

`docs/stereotypes/relations/historical-dependence.md`

## Accepted signals

- `S-001` / Group 1: remove `Phase 1` project self-reference from the source-description sentence.
- `S-002` / Group 2: remove `Phase 1 consolidation` project/process self-reference from the historical-grounding sentence.

## Rejected or deferred signals

- None.

## Changes

- Replaced `supplied Phase 1 sources` with `supplied sources`.
- Replaced `For this Phase 1 consolidation, this supports treating historical grounding cautiously:` with `This supports treating historical grounding cautiously:`.

## Review notes

This PR applies only safe local language-style edits. It does not perform conceptual validation, source-faithfulness validation, source checking, citation-support assessment, reference hygiene, Markdown hygiene, encoding hygiene, page-structure checking, or broad rewriting.