### PR TITLE
Resolve language-style signals for relations/participational

### DIFF
--- a/docs/stereotypes/relations/participational.md
+++ b/docs/stereotypes/relations/participational.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Participational is introduced in the supplied Phase 1 evidence as a stereotype for event part-whole relations that decompose an Event into participations. The decomposition is characterized as constructed: participational portions are projected from a whole event by considering their formal dependence on specific endurants.
+Participational is introduced as a stereotype for event part-whole relations that decompose an Event into participations. The decomposition is characterized as constructed: participational portions are projected from a whole event by considering their formal dependence on specific endurants.
 
 A participational portion is described as maximal with respect to the property under consideration and disjoint from other portions produced by the same criterion. The same source states that the maximum cardinality at the association end attached to the participant is always one, reflecting the rule that participations depend exclusively on a single endurant.
 


### PR DESCRIPTION
## Summary

Resolves accepted `language-style-checker` signals from #33.

## Affected page

`docs/stereotypes/relations/participational.md`

## Accepted signals

- `S-001` — removes project/process self-reference from the Description section.

## Rejected or deferred signals

- None.

## Changes

- Removes the phrase `in the supplied Phase 1 evidence` from the opening Description sentence.

## Review notes

This PR applies only safe local language-style edits. It does not perform conceptual validation, source-faithfulness validation, source checking, citation-support assessment, reference hygiene, Markdown hygiene, encoding hygiene, page-structure checking, or broad rewriting.