### PR TITLE
Resolve language-style signals for relations/participation

### DIFF
--- a/docs/stereotypes/relations/participation.md
+++ b/docs/stereotypes/relations/participation.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Participation is used in the Phase 1 sources to represent how endurants or objects are involved in events or perdurants. At the OntoUML modeling level, Participation is described as an association stereotype connecting an Event class to a class denoting an endurant type. It is the main connection between modeled events and the endurant types that participate in them.
+Participation is used in the sources to represent how endurants or objects are involved in events or perdurants. At the OntoUML modeling level, Participation is described as an association stereotype connecting an Event class to a class denoting an endurant type. It is the main connection between modeled events and the endurant types that participate in them.
 
 The sources ground this connection in an underlying event account. One recurrent characterization treats a participation as the event portion that depends exclusively on a single object. In this account, `participationOf` is derived from exclusive dependence between that event portion and the object, rather than introduced as primitive. Participation can apply to atomic events that manifest dispositions and to complex events that have such atomic events as parts; participations may themselves be atomic or complex. The participation view is therefore presented as orthogonal to a purely mereological decomposition of events.
 


### PR DESCRIPTION
## Summary

Resolves accepted `language-style-checker` signals from #32.

## Affected page

`docs/stereotypes/relations/participation.md`

## Accepted signals

- `S-001` (`project_self_reference`): removes the project-phase phrase `Phase 1` from the Description section.

## Rejected or deferred signals

- None.

## Changes

- Replaces `used in the Phase 1 sources` with `used in the sources`.

## Review notes

This PR applies only safe local language-style edits. It does not perform conceptual validation, source-faithfulness validation, source checking, citation-support assessment, reference hygiene, Markdown hygiene, encoding hygiene, page-structure checking, or broad rewriting.