### PR TITLE
Resolve language-style signals for relations/creation

### DIFF
--- a/docs/stereotypes/relations/creation.md
+++ b/docs/stereotypes/relations/creation.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Creation connects an Event with the endurant or Object it brings into existence. The intermediate sources characterize Creation as an event-to-endurant relation, and one source describes `<<creation>>` as a special kind of Participation. In this Phase 1 evidence, Creation belongs to the broader event-extension account in which Event occurrences record changes affecting endurants, including Creation, Termination, property change, and Participation.
+Creation connects an Event with the endurant or Object it brings into existence. The intermediate sources characterize Creation as an event-to-endurant relation, and one source describes `<<creation>>` as a special kind of Participation. In the evidence, Creation belongs to the broader event-extension account in which Event occurrences record changes affecting endurants, including Creation, Termination, property change, and Participation.
 
 For past modeled Event occurrences, a Creation relation fixes which endurant was created by the Event. The source-specific contribution that discusses `<<creation>>` therefore applies an immutability rule to association ends attached to endurants in Creation associations: they should be read-only because the past Event cannot change which endurant it created.
 


### PR DESCRIPTION
## Summary

Resolves accepted `language-style-checker` signals from #27.

## Affected page

`docs/stereotypes/relations/creation.md`

## Accepted signals

- `S-001` (`project_self_reference`): removes reader-facing project-phase wording from the Description section.

## Rejected or deferred signals

- None.

## Changes

- Replaces `In this Phase 1 evidence` with `In the evidence`.

## Review notes

This PR applies only safe local language-style edits. It does not perform conceptual validation, source-faithfulness validation, source checking, citation-support assessment, reference hygiene, Markdown hygiene, encoding hygiene, page-structure checking, or broad rewriting.